### PR TITLE
fix: allow to install recent google/cloud versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "ext-json": "*",
         "symfony/security-bundle": "^4.0 || ^5.0",
         "symfony/monolog-bundle": "^3.6",
-        "google/cloud": "^0.111.0"
+        "google/cloud": ">=0.111.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",


### PR DESCRIPTION
Caret constraint was too strict with MAJOR < 1.

In our case, `^0.111.0` <=> `>= 0.111.0 && < 0.112.0`

I advice replace it with less strict rule.